### PR TITLE
overlay: Update Telecomm service config

### DIFF
--- a/overlay/packages/services/Telecomm/res/values/config.xml
+++ b/overlay/packages/services/Telecomm/res/values/config.xml
@@ -21,6 +21,5 @@
     <bool name="tty_enabled">true</bool>
     
     <!-- Flag indicating if the speed up audio on mt call code should be executed -->
-    <bool name="config_speed_up_audio_on_mt_calls">true</bool>
-
+    <add-resource type="bool" name="config_speed_up_audio_on_mt_calls">true</add-resource>
 </resources>

--- a/overlay/packages/services/Telecomm/res/values/config.xml
+++ b/overlay/packages/services/Telecomm/res/values/config.xml
@@ -20,6 +20,4 @@
     <!-- Flag indicating if the tty is enabled -->
     <bool name="tty_enabled">true</bool>
     
-    <!-- Flag indicating if the speed up audio on mt call code should be executed -->
-    <add-resource type="bool" name="config_speed_up_audio_on_mt_calls">true</add-resource>
 </resources>

--- a/system.prop
+++ b/system.prop
@@ -115,7 +115,7 @@ ro.sys.fw.trim_cache_percent=100
 ro.sys.fw.trim_enable_memory=1073741824
 
 # OTA
-cm.updater.uri=https://ota.randomdroids.com/api
+# cm.updater.uri=https://ota.randomdroids.com/api
 
 # USB
 ro.sys.usb.default.config=diag,serial_smd,serial_tty,mass_storage,adb


### PR DESCRIPTION
Revert audio speedup on mt call patches from qcom

AOSP has their own implementation now in 5.1.1_r37

See: https://review.cyanogenmod.org/#/c/139451
